### PR TITLE
tweet when an onion service is available for a news org

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+twython
+pyyaml
+requests

--- a/stntweets.py
+++ b/stntweets.py
@@ -64,6 +64,9 @@ def compare_results(old_site, new_site):
 
         site_tweets.append("🤖 " + new_site['name'] + " is now on the HSTS preload list for major browsers, protecting user privacy. Bravo. https://securethe.news/sites")
 
+    if (new_site.get('onion_available', False) and not old_site.get('onion_available', False)):
+        site_tweets.append("🤖 " + new_site['name'] + " provides a @torproject onion service to protect reader privacy and enable censorship circumvention! https://securethe.news/sites")
+
     return site_tweets
 
 def tweet_results(tweets, twitter):
@@ -114,6 +117,7 @@ def main():
                 site['latest_scan']['defaults_to_https'],
             'hsts':site['latest_scan']['hsts'],
             'hsts_preloaded':site['latest_scan']['hsts_preloaded'],
+            'onion_available':site['latest_scan'].get('onion_available', False),
             'url':'https://securethe.news/sites/' + site['slug']})
 
 # Open existing results to compare to the new ones, if they exist.

--- a/test_stntweets.py
+++ b/test_stntweets.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import unittest
+
+from stntweets import get_site_name
+
+
+class TestSTNTweets(unittest.TestCase):
+    def test_get_site_name_no_handle(self):
+        self.assertEqual(get_site_name("Deutsche Welle", None), "Deutsche Welle")
+
+    def test_get_site_name_handle(self):
+        self.assertEqual(get_site_name("Deutsche Welle", "@dwnews"), "Deutsche Welle (@dwnews)")
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
I think this sounds like a good tweet but open to feedback!

This is in draft mode until the corresponding STN change is merged (in case issues come up in review over there).

Using `dict.get(key, default)` here to avoid a `KeyError` in case:
1. this change is deployed prior to the corresponding STN change [0] or,
2. the bot compares with a prior scan that lacks the `onion_available` key (i.e. on first run)

### run tests

```python test_stntweets.py```

[0] https://github.com/freedomofpress/securethenews/pull/262